### PR TITLE
Fix result set data type issue by selecting the value directly.

### DIFF
--- a/lib/rack/ecg/check/migration_version.rb
+++ b/lib/rack/ecg/check/migration_version.rb
@@ -8,9 +8,7 @@ module Rack
           begin
             if defined?(ActiveRecord)
               connection = ActiveRecord::Base.connection
-              result_set = connection.execute("select max(version) as version from schema_migrations")
-              version = result_set.first
-              value = version["version"]
+              value = connection.select_value("select max(version) from schema_migrations")
             else
               status = "error"
               value = "ActiveRecord not found"

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe "when used as middleware" do
           version = "123456"
           connection = double("connection")
           expect(ActiveRecord::Base).to receive(:connection).and_return(connection)
-          expect(connection).to receive(:execute).
-            with("select max(version) as version from schema_migrations").
-            and_return([{"version" => version}])
+          expect(connection).to receive(:select_value).
+            with("select max(version) from schema_migrations").
+            and_return(version)
           get "/_ecg"
           expect(json_body["migration_version"]["status"]).to eq("ok")
           expect(json_body["migration_version"]["value"]).to eq(version)


### PR DESCRIPTION
### Issue
```
{
  "migration_version": {
    "status": "error",
    "value": "no implicit conversion of String into Integer"
  }
}
```

### Fix
Mysql2 gem returns `Array` rather than `Hash` in `ActiveRecord::Base.connection.execute`. Using `#select_value` simplifies the return type and avoids the data type incompatibility issue.

See: http://stackoverflow.com/questions/5760100/why-does-rails-3-with-mysql2-gem-activerecordbase-connection-executesql-retu

/cc @madlep @warrenseen