### PR TITLE
Add hook option to rack ECG for logging

### DIFF
--- a/lib/rack/ecg/version.rb
+++ b/lib/rack/ecg/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class ECG
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -70,6 +70,22 @@ RSpec.describe "when used as middleware" do
       end
     end
 
+    context "when hook config option is set" do
+      let(:hook_proc) { instance_double(Proc) }
+      let(:options) {
+        { hook: hook_proc, checks: :error }
+      }
+
+      it "executes the hook proc with success status and check results as params" do
+        expect(hook_proc).to receive(:call) do |success, check_results|
+          expect(success).to be_falsey
+          expect(check_results).to have_key(:error)
+        end
+        get "_ecg"
+        expect(last_response.status).to eq(500)
+      end
+    end
+
     context "git revision" do
       let(:options) {
         { checks: [:git_revision] }


### PR DESCRIPTION
When a healthcheck fails, we want the opportunity to log what happened.

There's a wide variety of ways this gem users may want to handle loggers depending on how they use the gem. Rather than use an array of options (logger, log level, log on failure, log on success, log format), the most generic way is probably to pass the checks results as arguments to a proc, and let users configure their own logging function.

cc @taoza @warrenseen