### PR TITLE
Add :active_record and :redis checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ HTTP responses can be returned. There are a number of built in checks that
 - `:migration_version` - this assumes you are using ActiveRecord migrations. It
   queries the `schema_versions` table and tells you what version the database is
 at.
+- `:active_record` - this checks if an ActiveRecord connection is active.
+- `:redis` - this checks if a Redis connection is active.
 
-So using `git_revision` and `migration_version` would look like:
+So using `git_revision`, `migration_version`, `active_record`, and `redis` would look like:
 
 ```ruby
-use Rack::ECG, checks: [:git_revision, :migration_version]
+use Rack::ECG, checks: [:git_revision, :migration_version, :active_record, :redis]
 ```
 
 ```
@@ -112,6 +114,14 @@ $ curl http://localhost:9292/_ecg
   "migration_version": {
     "status": "ok",
     "value": "20150319050250"
+  },
+  "active_record": {
+    "status": "ok",
+    "value": "true"
+  },
+  "redis": {
+    "status": "ok",
+    "value": "true"
   }
 }
 ```

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -3,6 +3,7 @@ require "rack/ecg/check/error"
 require "rack/ecg/check/git_revision"
 require "rack/ecg/check/http"
 require "rack/ecg/check/migration_version"
+require "rack/ecg/check/active_record_connection"
 
 module Rack
   class ECG

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -4,6 +4,7 @@ require "rack/ecg/check/git_revision"
 require "rack/ecg/check/http"
 require "rack/ecg/check/migration_version"
 require "rack/ecg/check/active_record_connection"
+require "rack/ecg/check/redis_connection"
 
 module Rack
   class ECG

--- a/lib/rack/ecg/check/active_record_connection.rb
+++ b/lib/rack/ecg/check/active_record_connection.rb
@@ -1,0 +1,28 @@
+module Rack
+  class ECG
+    module Check
+      class ActiveRecordConnection
+        def result
+          value = ""
+          status = "ok"
+          begin
+            if defined?(ActiveRecord)
+              value = ::ActiveRecord::Base.connection.active?
+              status = value ? "ok" : "error"
+            else
+              status = "error"
+              value = "ActiveRecord not found"
+            end
+          rescue => e
+            status = "error"
+            value = e.message
+          end
+
+          Result.new(:active_record, status, value.to_s)
+        end
+
+        CheckRegistry.instance.register(:active_record, ActiveRecordConnection)
+      end
+    end
+  end
+end

--- a/lib/rack/ecg/check/redis_connection.rb
+++ b/lib/rack/ecg/check/redis_connection.rb
@@ -1,0 +1,28 @@
+module Rack
+  class ECG
+    module Check
+      class RedisConnection
+        def result
+          value = ""
+          status = "ok"
+          begin
+            if defined?(::Redis)
+              value = ::Redis.current.connected?
+              status = value ? "ok" : "error"
+            else
+              status = "error"
+              value = "Redis not found"
+            end
+          rescue => e
+            status = "error"
+            value = e.message
+          end
+
+          Result.new(:redis, status, value.to_s)
+        end
+
+        CheckRegistry.instance.register(:redis, RedisConnection)
+      end
+    end
+  end
+end

--- a/lib/rack/ecg/version.rb
+++ b/lib/rack/ecg/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class ECG
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -190,5 +190,35 @@ RSpec.describe "when used as middleware" do
         end
       end
     end
+
+    context "redis" do
+      let(:options) {
+        { checks: [:redis] }
+      }
+      context "when availabile" do
+        it "is reported" do
+          class Redis
+            def self.current
+            end
+          end
+          connected = true
+          instance = double("current")
+          expect(Redis).to receive(:current).and_return(instance)
+          expect(instance).to receive(:connected?).and_return(connected)
+          get "/_ecg"
+          expect(json_body["redis"]["status"]).to eq("ok")
+          expect(json_body["redis"]["value"]).to eq(connected.to_s)
+        end
+      end
+
+      context "when not available" do
+        it "is reported" do
+          Object.send(:remove_const, :Redis) if defined?(Redis)
+          get "/_ecg"
+          expect(json_body["redis"]["status"]).to eq("error")
+          expect(json_body["redis"]["value"]).to eq("Redis not found")
+        end
+      end
+    end
   end
 end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "when used as middleware" do
       let(:options) {
         { checks: [:migration_version] }
       }
-      context "when availabile" do
+      context "when available" do
         it "is reported" do
           class ActiveRecord
             class Base
@@ -163,7 +163,7 @@ RSpec.describe "when used as middleware" do
       let(:options) {
         { checks: [:active_record] }
       }
-      context "when availabile" do
+      context "when available" do
         it "is reported" do
           class ActiveRecord
             class Base
@@ -195,7 +195,7 @@ RSpec.describe "when used as middleware" do
       let(:options) {
         { checks: [:redis] }
       }
-      context "when availabile" do
+      context "when available" do
         it "is reported" do
           class Redis
             def self.current


### PR DESCRIPTION
This PR adds the `:active_record` and `:redis` checks, which succeed when an active connection is established.

Envato has been using these checks internally for over a year now and would like to add them to this gem for others to use.