### PR TITLE
Add a Sequel health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $ curl http://localhost:9292/_ecg
 }
 ```
 
-Because the `sequel` check operates on a per-connection bases, you can specify multiple Sequel databases to independently check, and provide a friendly name for disambiguation purposes:
+Because the `sequel` check operates on a per-connection basis, you can specify multiple Sequel databases to independently check, and provide a friendly name for disambiguation purposes:
 
 ```ruby
 use Rack::ECG, checks: [

--- a/README.md
+++ b/README.md
@@ -126,6 +126,56 @@ $ curl http://localhost:9292/_ecg
 }
 ```
 
+#### Checks with parameters
+Some checks, such as the `sequel` check, require a parameter hash. In this case, you must provide the check as a tuple consisting of both the check name, and a hash of parameters:
+
+```ruby
+use Rack::ECG, checks: [:http, [:sequel, {connection: "sqlite://my-sqlite.db"}]]
+```
+
+```
+$ curl http://localhost:9292/_ecg
+{
+  "http": {
+    "status": "ok",
+    "value": "online"
+  },
+  "sequel": {
+    "status": "ok",
+    "value": "true"
+  }
+}
+```
+
+Because the `sequel` check operates on a per-connection bases, you can specify multiple Sequel databases to independently check, and provide a friendly name for disambiguation purposes:
+
+```ruby
+use Rack::ECG, checks: [
+  :http,
+  [:sequel, {connection: 'sqlite://events.db', name: 'events'}],
+  [:sequel, {connection: 'sqlite://projections.db', name: 'projections'}]
+]
+```
+
+```
+$ curl http://localhost:9292/_ecg
+
+{
+  "http": {
+    "status": "ok",
+    "value": "online"
+  },
+  "sequel_events": {
+    "status": "ok",
+    "value": "true"
+  },
+  "sequel_projections": {
+    "status": "ok",
+    "value": "true"
+  }
+}
+```
+
 ### `at`
 
 By default `Rack::ECG` is mapped to a URL of `/_ecg`, you can set this to
@@ -188,7 +238,7 @@ For larger new features: Do everything as above, but first also make contact wit
 
 ## About
 
-This project is maintained by the [Envato engineering team][webuild] and funded by [Envato][envato]. 
+This project is maintained by the [Envato engineering team][webuild] and funded by [Envato][envato].
 
 [<img src="http://opensource.envato.com/images/envato-oss-readme-logo.png" alt="Envato logo">][envato]
 

--- a/examples/parameters.ru
+++ b/examples/parameters.ru
@@ -1,0 +1,11 @@
+require 'rack/ecg'
+require 'sequel'
+require 'sqlite3'
+
+use Rack::ECG, checks: [
+  :http,
+  [:sequel, {connection: 'sqlite://events.db', name: 'events'}],
+  [:sequel, {connection: 'sqlite://projections.db', name: 'projections'}]
+]
+
+run -> (env) { [200, {}, ["Hello, World"]] }

--- a/lib/rack/ecg.rb
+++ b/lib/rack/ecg.rb
@@ -24,7 +24,7 @@ module Rack
           results.merge(check.result.to_json)
         end
 
-        success = check_results.none? { |check| check[1][:status] == "error" }
+        success = check_results.none? { |check| check[1][:status] == Check::Status::ERROR }
 
         response_status = success ? 200 : 500
 

--- a/lib/rack/ecg.rb
+++ b/lib/rack/ecg.rb
@@ -12,7 +12,7 @@ module Rack
       @app = app
 
       check_configuration = options.delete(:checks) || []
-      @check_factory = CheckFactory.new(check_configuration, default_checks: DEFAULT_CHECKS)
+      @check_factory = CheckFactory.new(check_configuration, DEFAULT_CHECKS)
       @at = options.delete(:at) || DEFAULT_MOUNT_AT
 
       @hook = options.delete(:hook)

--- a/lib/rack/ecg.rb
+++ b/lib/rack/ecg.rb
@@ -1,7 +1,7 @@
 require "rack/ecg/version"
 require "json"
 require "open3"
-require "rack/ecg/check"
+require "rack/ecg/check_factory"
 
 module Rack
   class ECG
@@ -11,9 +11,8 @@ module Rack
     def initialize(app=nil, options={})
       @app = app
 
-      check_names = options.delete(:checks) || []
-      @check_classes = build_check_classes(check_names)
-
+      check_configuration = options.delete(:checks) || []
+      @check_factory = CheckFactory.new(check_configuration, default_checks: DEFAULT_CHECKS)
       @at = options.delete(:at) || DEFAULT_MOUNT_AT
 
       @hook = options.delete(:hook)
@@ -21,11 +20,9 @@ module Rack
 
     def call(env)
       if env["PATH_INFO"] == @at
-
-        check_results = @check_classes.inject({}){|results, (check_class, check_params)|
-          check = check_params.nil? ? check_class.new : check_class.new(check_params)
+        check_results = @check_factory.build_all.inject({}) do |results, check|
           results.merge(check.result.to_json)
-        }
+        end
 
         success = check_results.none? { |check| check[1][:status] == "error" }
 
@@ -46,17 +43,6 @@ module Rack
       else
         [404, {},[]]
       end
-    end
-
-    private
-    def build_check_classes(check_names)
-      check_names = Array(check_names) # handle nil, or not a list
-      check_names = check_names | DEFAULT_CHECKS # add the :http check if it's not there
-      check_names.map { |check_name, check_params|
-        check_class = CheckRegistry.instance[check_name]
-        raise "Don't know about check #{check_name}" unless check_class
-        [check_class, check_params]
-      }
     end
   end
 end

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -5,6 +5,7 @@ require "rack/ecg/check/http"
 require "rack/ecg/check/migration_version"
 require "rack/ecg/check/active_record_connection"
 require "rack/ecg/check/redis_connection"
+require "rack/ecg/check/sequel_connection"
 
 module Rack
   class ECG

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -10,6 +10,11 @@ require "rack/ecg/check/sequel_connection"
 module Rack
   class ECG
     module Check
+      module Status
+        OK = "ok".freeze
+        ERROR = "error".freeze
+      end
+
       class Result < Struct.new(:name, :status, :value)
         def to_json
           {name => {:status => status, :value => value}}

--- a/lib/rack/ecg/check/active_record_connection.rb
+++ b/lib/rack/ecg/check/active_record_connection.rb
@@ -4,17 +4,17 @@ module Rack
       class ActiveRecordConnection
         def result
           value = ""
-          status = "ok"
+          status = Status::OK
           begin
             if defined?(ActiveRecord)
               value = ::ActiveRecord::Base.connection.active?
-              status = value ? "ok" : "error"
+              status = value ? Status::OK : Status::ERROR
             else
-              status = "error"
+              status = Status::ERROR
               value = "ActiveRecord not found"
             end
           rescue => e
-            status = "error"
+            status = Status::ERROR
             value = e.message
           end
 

--- a/lib/rack/ecg/check/error.rb
+++ b/lib/rack/ecg/check/error.rb
@@ -5,7 +5,7 @@ module Rack
       # this is basically a "hello-world"
       class Error
         def result
-          Result.new(:error, "error", "PC LOAD LETTER")
+          Result.new(:error, Status::ERROR, "PC LOAD LETTER")
         end
       end
 

--- a/lib/rack/ecg/check/git_revision.rb
+++ b/lib/rack/ecg/check/git_revision.rb
@@ -7,7 +7,7 @@ module Rack
 
           success = wait_thread.value.success?
 
-          status = success ? "ok" : "error"
+          status = success ? Status::OK : Status::ERROR
 
           value = success ? stdout.read : stderr.read
           value = value.strip

--- a/lib/rack/ecg/check/http.rb
+++ b/lib/rack/ecg/check/http.rb
@@ -5,7 +5,7 @@ module Rack
       # this is basically a "hello-world"
       class Http
         def result
-          Result.new(:http, "ok", "online")
+          Result.new(:http, Status::OK, "online")
         end
       end
 

--- a/lib/rack/ecg/check/migration_version.rb
+++ b/lib/rack/ecg/check/migration_version.rb
@@ -4,17 +4,17 @@ module Rack
       class MigrationVersion
         def result
           value = ""
-          status = "ok"
+          status = Status::OK
           begin
             if defined?(ActiveRecord)
               connection = ActiveRecord::Base.connection
               value = connection.select_value("select max(version) from schema_migrations")
             else
-              status = "error"
+              status = Status::ERROR
               value = "ActiveRecord not found"
             end
           rescue => e
-            status = "error"
+            status = Status::ERROR
             value = e.message
           end
 

--- a/lib/rack/ecg/check/redis_connection.rb
+++ b/lib/rack/ecg/check/redis_connection.rb
@@ -4,17 +4,17 @@ module Rack
       class RedisConnection
         def result
           value = ""
-          status = "ok"
+          status = Status::OK
           begin
             if defined?(::Redis)
               value = ::Redis.current.connected?
-              status = value ? "ok" : "error"
+              status = value ? Status::OK : Status::ERROR
             else
-              status = "error"
+              status = Status::ERROR
               value = "Redis not found"
             end
           rescue => e
-            status = "error"
+            status = Status::ERROR
             value = e.message
           end
 

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -15,7 +15,7 @@ module Rack
             if connection_parameters.nil?
               status = Status::ERROR
               value = "Sequel Connection parameters not found"
-            elsif defined?(Sequel)
+            elsif defined?(::Sequel)
               ::Sequel.connect(connection_parameters) { |db|
                 value = db.test_connection
                 status = Status::OK

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -1,0 +1,40 @@
+module Rack
+  class ECG
+    module Check
+      class SequelConnection
+        attr_reader :connection_parameters, :name
+        def initialize(parameters = {})
+          puts parameters
+          @connection_parameters = parameters[:connection]
+          @name = parameters[:name]
+        end
+
+        def result
+          value = ""
+          status = "ok"
+          begin
+            if connection_parameters.nil?
+              status = "error"
+              value = "Sequel Connection parameters not found"
+            elsif defined?(Sequel)
+              ::Sequel.connect(connection_parameters) { |db|
+                value = db.valid_connection?
+                status = "#{name || db.inspect} #{value ? "ok" : "error"}"
+              }
+            else
+              status = "error"
+              value = "Sequel not found"
+            end
+          rescue => e
+            status = "error"
+            value = e.message
+          end
+
+          Result.new(:sequel, status, value.to_s)
+        end
+
+        CheckRegistry.instance.register(:sequel, SequelConnection)
+      end
+    end
+  end
+end

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -18,7 +18,7 @@ module Rack
               value = "Sequel Connection parameters not found"
             elsif defined?(Sequel)
               ::Sequel.connect(connection_parameters) { |db|
-                value = db.valid_connection?
+                value = db.test_connection
                 status = "#{name || db.inspect} #{value ? "ok" : "error"}"
               }
             else

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -4,7 +4,6 @@ module Rack
       class SequelConnection
         attr_reader :connection_parameters, :name
         def initialize(parameters = {})
-          puts parameters
           @connection_parameters = parameters[:connection]
           @name = parameters[:name]
         end

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -18,7 +18,7 @@ module Rack
             elsif defined?(Sequel)
               ::Sequel.connect(connection_parameters) { |db|
                 value = db.test_connection
-                status = "#{name || db.inspect} #{value ? "ok" : "error"}"
+                status = "ok"
               }
             else
               status = "error"
@@ -29,7 +29,15 @@ module Rack
             value = e.message
           end
 
-          Result.new("sequel #{name.downcase}".gsub(/\W+/, '_').to_sym, status, value.to_s)
+          Result.new(result_key.to_sym, status, value.to_s)
+        end
+
+        def result_key
+          if name
+            "sequel #{name.downcase}".gsub(/\W+/, '_')
+          else
+            "sequel"
+          end
         end
 
         CheckRegistry.instance.register(:sequel, SequelConnection)

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -10,22 +10,22 @@ module Rack
 
         def result
           value = ""
-          status = "ok"
+          status = Status::OK
           begin
             if connection_parameters.nil?
-              status = "error"
+              status = Status::ERROR
               value = "Sequel Connection parameters not found"
             elsif defined?(Sequel)
               ::Sequel.connect(connection_parameters) { |db|
                 value = db.test_connection
-                status = "ok"
+                status = Status::OK
               }
             else
-              status = "error"
+              status = Status::ERROR
               value = "Sequel not found"
             end
           rescue => e
-            status = "error"
+            status = Status::ERROR
             value = e.message
           end
 

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -29,7 +29,7 @@ module Rack
             value = e.message
           end
 
-          Result.new(:sequel, status, value.to_s)
+          Result.new("sequel #{name.downcase}".gsub(/\W+/, '_').to_sym, status, value.to_s)
         end
 
         CheckRegistry.instance.register(:sequel, SequelConnection)

--- a/lib/rack/ecg/check_factory.rb
+++ b/lib/rack/ecg/check_factory.rb
@@ -5,7 +5,7 @@ module Rack
     class CheckFactory
       CheckDefinition = Struct.new(:check_class, :parameters)
 
-      def initialize(definitions, default_checks: [])
+      def initialize(definitions, default_checks = [])
         definitions = Array(definitions) | default_checks
 
         @checks = definitions.map do |check_name, check_parameters|
@@ -15,11 +15,11 @@ module Rack
 
       def build_all
         @checks.map do |check_definition|
-          build(check_class: check_definition.check_class, parameters: check_definition.parameters)
+          build(check_definition.check_class, check_definition.parameters)
         end
       end
 
-      def build(check_class:, parameters: nil)
+      def build(check_class, parameters = nil)
         parameters.nil? ? check_class.new : check_class.new(parameters)
       end
     end

--- a/lib/rack/ecg/check_factory.rb
+++ b/lib/rack/ecg/check_factory.rb
@@ -1,0 +1,27 @@
+require "rack/ecg/check"
+
+module Rack
+  class ECG
+    class CheckFactory
+      CheckDefinition = Struct.new(:check_class, :parameters)
+
+      def initialize(definitions, default_checks: [])
+        definitions = Array(definitions) | default_checks
+
+        @checks = definitions.map do |check_name, check_parameters|
+          CheckDefinition.new(CheckRegistry.lookup(check_name), check_parameters)
+        end
+      end
+
+      def build_all
+        @checks.map do |check_definition|
+          build(check_class: check_definition.check_class, parameters: check_definition.parameters)
+        end
+      end
+
+      def build(check_class:, parameters: nil)
+        parameters.nil? ? check_class.new : check_class.new(parameters)
+      end
+    end
+  end
+end

--- a/lib/rack/ecg/check_registry.rb
+++ b/lib/rack/ecg/check_registry.rb
@@ -3,6 +3,7 @@ require "singleton"
 module Rack
   class ECG
     class CheckRegistry
+      CheckNotRegistered = Class.new(StandardError)
       include Singleton
 
       def initialize()
@@ -13,8 +14,16 @@ module Rack
         @registry[name] = check_class
       end
 
-      def [](name)
-        @registry[name]
+      def lookup(name)
+        @registry.fetch(name) { raise CheckNotRegistered.new("Check '#{name}' is not registered") }
+      end
+
+      def self.lookup(name)
+        instance.lookup(name)
+      end
+
+      def self.register(name, check_class)
+        instance.register(name, check_class)
       end
     end
   end

--- a/spec/check_factory_spec.rb
+++ b/spec/check_factory_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe Rack::ECG::CheckFactory do
+  class MyCheckClass; end
+  class MyOtherCheckClass; def initialize(params); end; end
+
+  let(:definitions) { [] }
+  let(:default_checks) { [] }
+  subject(:check_factory) { Rack::ECG::CheckFactory.new(definitions, default_checks: default_checks) }
+
+  describe "#build" do
+    context "with a class that does not take params" do
+      let(:check_class) { spy(MyCheckClass) }
+
+      it "builds the specified class" do
+        expect { check_factory.build(check_class: check_class) }.not_to raise_error
+        expect(check_class).to have_received(:new).with(no_args)
+      end
+    end
+
+    context "with a class that does not take params" do
+      let(:check_class) { spy(MyOtherCheckClass) }
+      let(:check_parameters) { double }
+      it "builds the specified class" do
+        expect { check_factory.build(check_class: check_class, parameters: check_parameters) }.not_to raise_error
+        expect(check_class).to have_received(:new).with(check_parameters)
+      end
+    end
+  end
+
+  describe "#build_all" do
+    context "with defined checks" do
+      let(:definitions) { [:my_check, [:my_other_check, {foo: 'bar'}]] }
+      let(:check_class) { spy(MyCheckClass) }
+      let(:other_check_class) { spy(MyOtherCheckClass) }
+      before do
+        allow(Rack::ECG::CheckRegistry).to receive(:lookup).with(:my_check).and_return(check_class)
+        allow(Rack::ECG::CheckRegistry).to receive(:lookup).with(:my_other_check).and_return(other_check_class)
+      end
+
+      it "builds all registered checks" do
+        check_factory.build_all
+        expect(check_class).to have_received(:new).with(no_args)
+        expect(other_check_class).to have_received(:new).with(foo: 'bar')
+      end
+    end
+
+    context "with defined default checks" do
+      let(:default_checks) { [:http] }
+      let(:http_class) { spy(Rack::ECG::Check::Http) }
+      before do
+        allow(Rack::ECG::CheckRegistry).to receive(:lookup).with(:http).and_return(http_class)
+      end
+
+      it "builds registered default checks" do
+        check_factory.build_all
+        expect(http_class).to have_received(:new).with(no_args)
+      end
+    end
+  end
+end

--- a/spec/check_factory_spec.rb
+++ b/spec/check_factory_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Rack::ECG::CheckFactory do
 
   let(:definitions) { [] }
   let(:default_checks) { [] }
-  subject(:check_factory) { Rack::ECG::CheckFactory.new(definitions, default_checks: default_checks) }
+  subject(:check_factory) { Rack::ECG::CheckFactory.new(definitions, default_checks) }
 
   describe "#build" do
     context "with a class that does not take params" do
       let(:check_class) { spy(MyCheckClass) }
 
       it "builds the specified class" do
-        expect { check_factory.build(check_class: check_class) }.not_to raise_error
+        expect { check_factory.build(check_class) }.not_to raise_error
         expect(check_class).to have_received(:new).with(no_args)
       end
     end
@@ -20,7 +20,7 @@ RSpec.describe Rack::ECG::CheckFactory do
       let(:check_class) { spy(MyOtherCheckClass) }
       let(:check_parameters) { double }
       it "builds the specified class" do
-        expect { check_factory.build(check_class: check_class, parameters: check_parameters) }.not_to raise_error
+        expect { check_factory.build(check_class, check_parameters) }.not_to raise_error
         expect(check_class).to have_received(:new).with(check_parameters)
       end
     end

--- a/spec/check_registry_spec.rb
+++ b/spec/check_registry_spec.rb
@@ -1,0 +1,23 @@
+
+RSpec.describe Rack::ECG::CheckRegistry do
+  class MyCheckClass; end
+  subject(:check_registry) { described_class }
+
+  before do
+    check_registry.register(:my_check, MyCheckClass)
+  end
+
+  describe ".lookup" do
+    context "with a registered class" do
+      it "returns the registered class" do
+        expect(check_registry.lookup(:my_check)).to eq(MyCheckClass)
+      end
+    end
+
+    context "when the class is not registered" do
+      it "raises an error" do
+        expect { check_registry.lookup(:my_other_check) }.to raise_error(Rack::ECG::CheckRegistry::CheckNotRegistered)
+      end
+    end
+  end
+end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "when used as middleware" do
             end
           end
           expect(Sequel).to receive(:connect).with('sqlite://').and_yield(instance)
-          expect(instance).to receive(:valid_connection?).and_return(true)
+          expect(instance).to receive(:test_connection).and_return(true)
           get "/_ecg"
           puts json_body["sequel"]
           expect(json_body["sequel"]["status"]).to eq("my-awesome-db ok")

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe "when used as middleware" do
           expect(Sequel).to receive(:connect).with('sqlite://').and_yield(instance)
           expect(instance).to receive(:test_connection).and_return(true)
           get "/_ecg"
-          expect(json_body["sequel_my_awesome_db"]["status"]).to eq("My Awesome DB ok")
+          expect(json_body["sequel_my_awesome_db"]["status"]).to eq("ok")
           expect(json_body["sequel_my_awesome_db"]["value"]).to eq("true")
         end
       end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -221,5 +221,27 @@ RSpec.describe "when used as middleware" do
         end
       end
     end
+
+    context "sequel" do
+      let(:options) {
+        { checks: [[:sequel, {name: 'my-awesome-db', connection: 'sqlite://'}]] }
+      }
+      let(:instance) { double("sequel_db") }
+
+      context "when available" do
+        it "is reported" do
+          class Sequel
+            def self.connect(_)
+            end
+          end
+          expect(Sequel).to receive(:connect).with('sqlite://').and_yield(instance)
+          expect(instance).to receive(:valid_connection?).and_return(true)
+          get "/_ecg"
+          puts json_body["sequel"]
+          expect(json_body["sequel"]["status"]).to eq("my-awesome-db ok")
+          expect(json_body["sequel"]["value"]).to eq("true")
+        end
+      end
+    end
   end
 end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe "when used as middleware" do
 
     context "sequel" do
       let(:options) {
-        { checks: [[:sequel, {name: 'my-awesome-db', connection: 'sqlite://'}]] }
+        { checks: [[:sequel, {name: 'My Awesome DB', connection: 'sqlite://'}]] }
       }
       let(:instance) { double("sequel_db") }
 
@@ -237,9 +237,8 @@ RSpec.describe "when used as middleware" do
           expect(Sequel).to receive(:connect).with('sqlite://').and_yield(instance)
           expect(instance).to receive(:test_connection).and_return(true)
           get "/_ecg"
-          puts json_body["sequel"]
-          expect(json_body["sequel"]["status"]).to eq("my-awesome-db ok")
-          expect(json_body["sequel"]["value"]).to eq("true")
+          expect(json_body["sequel_my_awesome_db"]["status"]).to eq("My Awesome DB ok")
+          expect(json_body["sequel_my_awesome_db"]["value"]).to eq("true")
         end
       end
     end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -129,6 +129,9 @@ RSpec.describe "when used as middleware" do
       let(:options) {
         { checks: [:migration_version] }
       }
+      let(:connection) { double("connection") }
+      let(:version) { "123456" }
+
       context "when available" do
         it "is reported" do
           class ActiveRecord
@@ -137,8 +140,6 @@ RSpec.describe "when used as middleware" do
               end
             end
           end
-          version = "123456"
-          connection = double("connection")
           expect(ActiveRecord::Base).to receive(:connection).and_return(connection)
           expect(connection).to receive(:select_value).
             with("select max(version) from schema_migrations").
@@ -164,6 +165,8 @@ RSpec.describe "when used as middleware" do
         { checks: [:active_record] }
       }
       context "when available" do
+        let(:active) { true }
+        let(:connection) { double("connection") }
         it "is reported" do
           class ActiveRecord
             class Base
@@ -171,8 +174,6 @@ RSpec.describe "when used as middleware" do
               end
             end
           end
-          active = true
-          connection = double("connection")
           expect(ActiveRecord::Base).to receive(:connection).and_return(connection)
           expect(connection).to receive(:active?).and_return(active)
           get "/_ecg"
@@ -196,13 +197,13 @@ RSpec.describe "when used as middleware" do
         { checks: [:redis] }
       }
       context "when available" do
+        let(:instance) { double("current") }
+        let(:connected) { true }
         it "is reported" do
           class Redis
             def self.current
             end
           end
-          connected = true
-          instance = double("current")
           expect(Redis).to receive(:current).and_return(instance)
           expect(instance).to receive(:connected?).and_return(connected)
           get "/_ecg"


### PR DESCRIPTION
We're using Sequel in a few projects now with Event Sourcery. Let's add a generic Sequel connection check that we can parameterise for our ES databases.