### PR TITLE
Extend documentation (including RDoc via YARD)

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--files lib/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: The Rack::ECG initializer now uses named options, instead of an
+  options hash. If you manually initialized an instance, you may need to use the
+  `**` operator to pass these options. (e.g. `Rack::ECG.new(nil, **options)`)
+
 ### Removed
 
 - Support for Ruby versions < 2.4.0

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 [![Gem version](https://img.shields.io/gem/v/rack-ecg)][gem-page]
 
-An easy to configure Rack middleware for Ruby web apps to provide a simple
-health check endpoint that tells you vital life signs about your app. All
-without the boilerplate service checking code you've written 10 times before.
+Rack middleware for Ruby web apps, providing a simple and extensible health
+check endpoint, with minimal configuration.
 
-(it's ECG as in electrocardiogram - as in the machine that monitors how your
-heart works)
+> Electrocardiogram (ECG): A recording of the electrical activity of the heart.
 
 ## Features
-- simple 1 line to drop into your `config.ru` or `config/application.rb` file to
-  set up
+
+- Start with a single line in your `config.ru` or `config/application.rb` file.
 - reports git revision status
 - reports ActiveRecord migration schema version
 - reports errors if any check can't be executed for whatever reason
@@ -25,23 +23,15 @@ APIs and features are almost certain to be in flux.
 
 ## Getting Started
 
-Add this line to your application's Gemfile:
+Add this to your application's `Gemfile`:
 
 ```ruby
-gem 'rack-ecg'
+gem 'rack-ecg', '~> 0.0.5`
 ```
 
-And then execute:
+Then run `bundle install`.
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install rack-ecg
-
-### Rails
-
-In Rails you can add `Rack::ECG` to your `config/application.rb` as a middleware
+In Rails you can add `Rack::ECG` to your `config/application.rb` as a middleware:
 
 ```ruby
 # config/application.rb
@@ -50,9 +40,7 @@ config.middleware.use Rack::ECG
 # ...
 ```
 
-### Rack
-
-In Rack apps, you can add `Rack::ECG` to your `config.ru`
+In Rack apps, you can add `Rack::ECG` to your `config.ru`:
 
 ```ruby
 # config.ru
@@ -62,6 +50,8 @@ use Rack::ECG
 
 run MyRackApp
 ```
+
+## Usage
 
 You can now hit your app and get a basic health check response from `Rack::ECG`
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,5 +12,5 @@ YARD::Rake::YardocTask.new
 task(default: [:rubocop, :spec, :yard])
 
 task(:'yard:server') do
-  sh "yard server --watch"
+  sh "yard server --reload"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,7 @@ RuboCop::RakeTask.new(:rubocop)
 YARD::Rake::YardocTask.new
 
 task(default: [:rubocop, :spec, :yard])
+
+task(:'yard:server') do
+  sh "yard server --watch"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,10 @@ require "bundler/gem_tasks"
 
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+require 'yard'
 
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new(:rubocop)
+YARD::Rake::YardocTask.new
 
-task(default: [:rubocop, :spec])
+task(default: [:rubocop, :spec, :yard])

--- a/lib/rack/ecg.rb
+++ b/lib/rack/ecg.rb
@@ -6,30 +6,45 @@ require "rack/ecg/check_factory"
 
 module Rack
   class ECG
+    # Default mount path.
     DEFAULT_MOUNT_AT = "/_ecg"
+    # Checks enabled by default.
     DEFAULT_CHECKS = [:http]
 
-    def initialize(app = nil, options = {})
+    # Constructs an instance of ECG Rack middleware with the specified
+    # options.
+    #
+    # @param [Object,nil] app Underlying Rack application to receive unmatched
+    #   requests. If unset, any unmatched requests will return a 404.
+    # @param [Array<Symbol, Array<Symbol, Object>>] checks: Sets and
+    #   configures the checks run by this instance. Defaults to
+    #   {ECG::DEFAULT_CHECKS}.
+    # @param [String, nil] at: Path which this ECG instance handles. Defaults
+    #   to {ECG::DEFAULT_MOUNT_AT}.
+    # @param [#call, nil] hook: Callable which receives the success status and
+    #   check results
+    def initialize(app = nil, checks: nil, at: DEFAULT_MOUNT_AT, hook: nil)
       @app = app
 
-      check_configuration = options.delete(:checks) || []
+      check_configuration = checks || []
       @check_factory = CheckFactory.new(check_configuration, DEFAULT_CHECKS)
-      @at = options.delete(:at) || DEFAULT_MOUNT_AT
+      @mount_at = at || DEFAULT_MOUNT_AT
 
-      @hook = options.delete(:hook)
+      @result_hook = hook
     end
 
+    # Rack compatible call method. Not intended for direct usage.
     def call(env)
-      if env["PATH_INFO"] == @at
+      if env["PATH_INFO"] == @mount_at
         check_results = @check_factory.build_all.inject({}) do |results, check|
-          results.merge(check.result.to_json)
+          results.merge(check.result.as_json)
         end
 
         success = check_results.none? { |check| check[1][:status] == Check::Status::ERROR }
 
         response_status = success ? 200 : 500
 
-        @hook&.call(success, check_results)
+        @result_hook&.call(success, check_results)
 
         response_headers = {
           "X-Rack-ECG-Version" => Rack::ECG::VERSION,

--- a/lib/rack/ecg.rb
+++ b/lib/rack/ecg.rb
@@ -17,13 +17,11 @@ module Rack
     # @param [Object,nil] app Underlying Rack application to receive unmatched
     #   requests. If unset, any unmatched requests will return a 404.
     # @param [Array<Symbol, Array<Symbol, Object>>] checks: Sets and
-    #   configures the checks run by this instance. Defaults to
-    #   {ECG::DEFAULT_CHECKS}.
-    # @param [String, nil] at: Path which this ECG instance handles. Defaults
-    #   to {ECG::DEFAULT_MOUNT_AT}.
+    #   configures the checks run by this instance.
+    # @param [String, nil] at: Path which this ECG instance handles.
     # @param [#call, nil] hook: Callable which receives the success status and
     #   check results
-    def initialize(app = nil, checks: nil, at: DEFAULT_MOUNT_AT, hook: nil)
+    def initialize(app = nil, checks: DEFAULT_CHECKS, at: DEFAULT_MOUNT_AT, hook: nil)
       @app = app
 
       check_configuration = checks || []

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -11,8 +11,11 @@ require "rack/ecg/check/sequel_connection"
 module Rack
   class ECG
     module Check
+      # Possible recognised check statuses.
       module Status
+        # Indicates the check was successful.
         OK = "ok"
+        # Indicates the check errored.
         ERROR = "error"
       end
 

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -17,8 +17,24 @@ module Rack
       end
 
       class Result < Struct.new(:name, :status, :value)
-        def to_json
+        # Format the result as a JSON compatible hash.
+        #
+        # @return [Hash<Object, Hash<Symbol, Object>>] Result in a hash format.
+        # @example A HTTP success response
+        #   puts result.as_json
+        #   # {:http=>{:status=>"ok", :value=>"online"}}
+        def as_json
           { name => { status: status, value: value } }
+        end
+
+        # Return the result as a JSON object.
+        #
+        # @return [String] Result in a JSON object string.
+        # @example A HTTP success response
+        #   puts result.to_json
+        #   # {"http": {"status": "ok", "value": "online"}}
+        def to_json
+          JSON.dump(as_json)
         end
       end
     end

--- a/lib/rack/ecg/check/active_record_connection.rb
+++ b/lib/rack/ecg/check/active_record_connection.rb
@@ -2,6 +2,9 @@
 module Rack
   class ECG
     module Check
+      # @!method initialize
+      #   Checks whether ActiveRecord is currently connected to the default
+      #   database.
       class ActiveRecordConnection
         def result
           value = ""

--- a/lib/rack/ecg/check/error.rb
+++ b/lib/rack/ecg/check/error.rb
@@ -2,8 +2,8 @@
 module Rack
   class ECG
     module Check
-      # if rack-ecg is serving a request - http is obviously working so far...
-      # this is basically a "hello-world"
+      # @!method initialize
+      #   Always returns a basic error for testing purposes.
       class Error
         def result
           Result.new(:error, Status::ERROR, "PC LOAD LETTER")

--- a/lib/rack/ecg/check/git_revision.rb
+++ b/lib/rack/ecg/check/git_revision.rb
@@ -2,6 +2,9 @@
 module Rack
   class ECG
     module Check
+      # @!method initialize
+      #   Returns the SHA1 of the current commit, as reported by the git
+      #   executable.
       class GitRevision
         def result
           _stdin, stdout, stderr, wait_thread = Open3.popen3("git rev-parse HEAD")

--- a/lib/rack/ecg/check/http.rb
+++ b/lib/rack/ecg/check/http.rb
@@ -2,8 +2,8 @@
 module Rack
   class ECG
     module Check
-      # if rack-ecg is serving a request - http is obviously working so far...
-      # this is basically a "hello-world"
+      # @!method initialize
+      #   Always returns a success.
       class Http
         def result
           Result.new(:http, Status::OK, "online")

--- a/lib/rack/ecg/check/migration_version.rb
+++ b/lib/rack/ecg/check/migration_version.rb
@@ -2,6 +2,9 @@
 module Rack
   class ECG
     module Check
+      # @!method initialize
+      #   Returns the latest applied ActiveRecord migration in the default
+      #   database.
       class MigrationVersion
         def result
           value = ""

--- a/lib/rack/ecg/check/redis_connection.rb
+++ b/lib/rack/ecg/check/redis_connection.rb
@@ -2,6 +2,11 @@
 module Rack
   class ECG
     module Check
+      # @!method initialize
+      #   Checks whether the global Redis client is currently connected to the
+      #   database.
+      #
+      #   Does not take any options.
       class RedisConnection
         def result
           value = ""

--- a/lib/rack/ecg/check/sequel_connection.rb
+++ b/lib/rack/ecg/check/sequel_connection.rb
@@ -4,6 +4,12 @@ module Rack
     module Check
       class SequelConnection
         attr_reader :connection_parameters, :name
+
+        # Checks whether Sequel can connect to the database identified by the
+        # ++connection++ option.
+        #
+        # @option parameters connection [String,Hash] Sequel connection parameters to check
+        # @option parameters name [String,nil] Name to distinguish multiple Sequel checks
         def initialize(parameters = {})
           @connection_parameters = parameters[:connection]
           @name = parameters[:name]

--- a/lib/rack/ecg/check_registry.rb
+++ b/lib/rack/ecg/check_registry.rb
@@ -4,25 +4,37 @@ require "singleton"
 module Rack
   class ECG
     class CheckRegistry
+      # Raised when a check didn't exist during lookup
       CheckNotRegistered = Class.new(StandardError)
       include Singleton
 
+      # Constructs the singleton instance of the registry
       def initialize
         @registry = {}
       end
 
+      # Register a check class by name
+      #
+      # @param [Symbol] name Desired check name
+      # @param [Class] check_class Class implementing check functionality
       def register(name, check_class)
         @registry[name] = check_class
       end
 
+      # Fetches the registered check class by name
+      #
+      # @param [Symbol] name Registered check name
+      # @raise [CheckNotRegistered] if the named check has not been registered
       def lookup(name)
         @registry.fetch(name) { raise CheckNotRegistered, "Check '#{name}' is not registered" }
       end
 
+      # (see #lookup)
       def self.lookup(name)
         instance.lookup(name)
       end
 
+      # (see #register)
       def self.register(name, check_class)
         instance.register(name, check_class)
       end

--- a/lib/rack/ecg/version.rb
+++ b/lib/rack/ecg/version.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Rack
   class ECG
+    # Library version.
     VERSION = "0.0.5"
   end
 end

--- a/rack-ecg.gemspec
+++ b/rack-ecg.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("pry", "~> 0.13.0")
   spec.add_development_dependency("rubocop-shopify", "~> 1.0.0")
   spec.add_development_dependency("yard", "~> 0.9.24")
+  spec.add_development_dependency("redcarpet", "~> 3.5.0")
 end

--- a/rack-ecg.gemspec
+++ b/rack-ecg.gemspec
@@ -28,9 +28,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("rack")
 
   spec.add_development_dependency("rake", "~> 13.0")
-  spec.add_development_dependency("bundler", "~> 2.1")
+  spec.add_development_dependency("bundler", "~> 2.1.4")
   spec.add_development_dependency("rspec", "~> 3.9.0")
   spec.add_development_dependency("rack-test", "~> 1.1.0")
   spec.add_development_dependency("pry", "~> 0.13.0")
-  spec.add_development_dependency("rubocop-shopify", "~> 1.0")
+  spec.add_development_dependency("rubocop-shopify", "~> 1.0.0")
+  spec.add_development_dependency("yard", "~> 0.9.24")
 end


### PR DESCRIPTION
I'm hoping to ensure the next release of `rack-ecg` includes comprehensive RDoc for consumers. Therefore, I've introduced YARD and added RDoc to most of the existing methods on classes I expect a consumer would use.