### PR TITLE
Enable Ruby 3.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: ["2.5", "2.6", "2.7", "3.0"]
     runs-on: ubuntu-latest
     name: Test (Ruby ${{ matrix.ruby }})
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7]
-        include:
-          - ruby: 3.0
-            experimental: true
+        ruby: [2.5, 2.6, 2.7, 3.0]
     runs-on: ubuntu-latest
     name: Test (Ruby ${{ matrix.ruby }})
     steps:
@@ -19,7 +16,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Run the default task
-      continue-on-error: ${{ matrix.experimental }}
       run: |
         gem install bundler -v 2.2.1
         bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# for running tests across different versions locally
+
+version: "3"
+services:
+  ruby30: &ruby30
+    image: ruby:3.0
+    volumes:
+      - ./:/app
+    command: bash -c 'gem update --system && cd /app && { ! [ -f Gemfile.lock ] || rm Gemfile.lock; } && bundle install && bundle exec rake'
+  ruby27:
+    <<: *ruby30
+    image: ruby:2.7
+  ruby26:
+    <<: *ruby30
+    image: ruby:2.6
+  ruby25:
+    <<: *ruby30
+    image: ruby:2.5

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("when used as middleware") do
   let(:app) do
     opts = options
     Rack::Builder.new do
-      use Rack::ECG, opts
+      use Rack::ECG, **opts
       run lambda { |env|
         if env["PATH_INFO"] == "/hello/world"
           [200, {}, ["Hello, World"]]


### PR DESCRIPTION
When I introduced the Ruby 3.0 checks earlier, they were failing, and I believed it would be necessary to update code. However, it appears that it was a specific issue with how the Rack middleware specs were passing their options.

### Changes

- Add a `docker-compose.yml` to facilitate testing the supported Ruby versions
- Fix argument passing in Rack middleware specs
- Require the build pipeline to pass for Ruby 3.0