### PR TITLE
Add a `static` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- The `static` check, which uses the provided check parameters to return the same result every time.
+
+
 ## [0.1.0] - 2020-12-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ use Rack::ECG, checks: [
   # no configuration required, or allowed
   :http,
   # passing configuration options
-  [:sequel, { name: "events", connection: "sqlite://events.db" }],
+  [:static, { name: "app", value: "my-cool-app" }],
   # some checks can be used multiple times
-  [:sequel, { name: "projections", connection: "sqlite://projections.db" }],
+  [:static, { name: "env", value: Rails.env }],
 ]
 ```
 
@@ -188,6 +188,32 @@ Returns the something in the following format on success:
   "sequel_events": {
     "status": "ok",
     "value": true
+  }
+}
+```
+
+#### `static`
+
+Returns the same value every time. Requires configuration, and can be configured multiple times.
+
+Given the following configuration:
+
+```ruby
+{
+  name: "image_build_url",               # must be unique per static check
+  success: true,                         # default value
+  status: Rack::ECG::Check::Status::OK,  # optional, overrides `success`
+  value: ENV["IMAGE_BUILD_URL"], 
+}
+```
+
+Returns the something in the following format:
+
+```json
+{
+  "image_build_url": {
+    "status": "ok",
+    "value": "https://example.com/pipelines/my-cool-app/builds/1234"
   }
 }
 ```

--- a/lib/rack/ecg/check.rb
+++ b/lib/rack/ecg/check.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 require "rack/ecg/check_registry"
+require "rack/ecg/check/active_record_connection"
 require "rack/ecg/check/error"
 require "rack/ecg/check/git_revision"
 require "rack/ecg/check/http"
 require "rack/ecg/check/migration_version"
-require "rack/ecg/check/active_record_connection"
 require "rack/ecg/check/redis_connection"
 require "rack/ecg/check/sequel_connection"
+require "rack/ecg/check/static"
 
 module Rack
   class ECG

--- a/lib/rack/ecg/check/error.rb
+++ b/lib/rack/ecg/check/error.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
+require_relative "./static"
+
 module Rack
   class ECG
     module Check
       # @!method initialize
       #   Always returns a basic error for testing purposes.
-      class Error
-        def result
-          Result.new(:error, Status::ERROR, "PC LOAD LETTER")
+      class Error < Static
+        STATIC_PARAMETERS = {
+          name: :error,
+          success: false,
+          value: "PC LOAD LETTER",
+        }.freeze
+
+        def initialize
+          super(STATIC_PARAMETERS)
         end
       end
 

--- a/lib/rack/ecg/check/http.rb
+++ b/lib/rack/ecg/check/http.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
+require_relative "./static"
+
 module Rack
   class ECG
     module Check
       # @!method initialize
       #   Always returns a success.
-      class Http
-        def result
-          Result.new(:http, Status::OK, "online")
+      class Http < Static
+        STATIC_PARAMETERS = {
+          name: :http,
+          success: true,
+          value: "online",
+        }.freeze
+
+        def initialize
+          super(STATIC_PARAMETERS)
         end
       end
 

--- a/lib/rack/ecg/check/static.rb
+++ b/lib/rack/ecg/check/static.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module Rack
+  class ECG
+    module Check
+      class Static
+        # Always returns the provided ++value++ under the ++name++ key, with the result set by ++status++.
+        #
+        # @example Return "Hello, world!" under ++static++
+        #   use(Rack::ECG, { checks: [[:static, { value: "Hello, world!" }]] })
+        #
+        # @example Return "Paper jam in tray 2" as an error under ++printer_status++
+        #   use(Rack::ECG, {
+        #     checks: [
+        #       [
+        #         :static,
+        #         {
+        #           value: "Paper jam in tray 2",
+        #           success: false, # or status: Rack::ECG::Check::Status::ERROR
+        #           name: :printer_status,
+        #         },
+        #       ],
+        #     ],
+        #   })
+        #
+        # @option parameters value [Object] (nil) Result value
+        # @option parameters status [Status::ERROR, Status::OK, nil] (nil) Result status (takes precedence over
+        #   ++success++)
+        # @option parameters success [Boolean] (true) Whether the result is successful
+        # @option parameters name [Symbol, #to_sym] (:static) Key for the check result in the response
+        def initialize(parameters)
+          parameters ||= {}
+
+          @name = parameters.fetch(:name, :static).to_sym
+          @value = parameters.fetch(:value, nil)
+
+          @status = if parameters.key?(:status)
+            parameters[:status]
+          else
+            parameters.fetch(:success, true) ? Status::OK : Status::ERROR
+          end
+        end
+
+        def result
+          Result.new(@name, @status, @value)
+        end
+      end
+
+      CheckRegistry.instance.register(:static, Static)
+    end
+  end
+end

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -243,5 +243,57 @@ RSpec.describe("when used as middleware") do
         end
       end
     end
+
+    context "static" do
+      let(:options) do
+        { checks: [[:static, static_options]] }
+      end
+
+      context "success is true" do
+        let(:static_options) do
+          { success: true, value: "ready" }
+        end
+
+        it "reports success" do
+          get "/_ecg"
+          expect(json_body["static"]["status"]).to(eq("ok"))
+          expect(json_body["static"]["value"]).to(eq("ready"))
+        end
+      end
+
+      context "success is false" do
+        let(:static_options) do
+          { success: false, value: "unhealthy" }
+        end
+
+        it "reports an error" do
+          get "/_ecg"
+          expect(json_body["static"]["status"]).to(eq("error"))
+          expect(json_body["static"]["value"]).to(eq("unhealthy"))
+        end
+      end
+
+      context "when a name is set" do
+        let(:static_options) do
+          { value: "this is the static value" }
+        end
+
+        it "reports under that name" do
+          get "/_ecg"
+          expect(json_body["static"]["value"]).to(eq("this is the static value"))
+        end
+      end
+
+      context "when status is set" do
+        let(:static_options) do
+          { value: "no error", success: false, status: "ok" }
+        end
+
+        it "reports that status" do
+          get "/_ecg"
+          expect(json_body["static"]["status"]).to(eq("ok"))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

At the moment, consumers of rack-ecg are expected to implement an entire new check in order to return a specific value. While this encourages consistency, it also adds barriers when attempting to return consistent sources of information returned in new ways.

For example, applications built into a Docker/OCI image often choose to embed a git revision or build number into the image itself, and don't include the git executable. In this scenario, there is no simple way to return that revision in a manner consistent with the existing GitRevision check.

The new Static check accepts a small set of parameters, and uses it to return an identical result on every invocation. One parameter (name) allows it to return the results under any desired check key, which provides a solution to the aforementioned issue.

#### Example usage

##### RAILS_ENV

```ruby
use Rack::ECG, checks: [[:static, { name: "rails_env", value: ENV["RAILS_ENV"] }]]
```

##### Memoized `git_revision` check

```ruby
git_revision = begin
  [:static, { name: "git_revision", value: File.read("REVISION") }]
rescue
  [:static, { name: "git_revision", success: false, value: "unable to read revision" }]
end

use Rack::ECG, checks: [git_revision]
```

### Changes

- Document the built-in rack-ecg checks in the README
- Add a `static` check
- Change the Http and Error checks to inherit from Static

### Follow-up

- [ ] Deprecate the `git_revision` check