### PR TITLE
Make RedisConnection Check Require Redis Instance Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: The Redis check now requires being configured with an instance of the Redis client, via the named `instance` parameter
+
 ### Added
 
 - The `static` check, which uses the provided check parameters to return the same result every time.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Requires a configured ActiveRecord connection, and that ActiveRecord migrations 
 
 #### `redis`
 
-Requires a configured global Redis client. Does not support configuration. Indicates whether the global client is currently connected to the Redis database. On success, returns something in the following format:
+Requires the Redis gem. Requires configuration, an instance of a Redis client. Indicates whether the Redis client passed in is currently connected to the Redis database. On success, returns something in the following format:
 
 ```json
 {

--- a/lib/rack/ecg/check/redis_connection.rb
+++ b/lib/rack/ecg/check/redis_connection.rb
@@ -8,21 +8,21 @@ module Rack
       #
       # @option parameters instance [Redis,Hash] Redis parameters to check
       class RedisConnection
-        attr_reader :instance_parameters
+        attr_reader :redis_instance
 
         def initialize(parameters = {})
-          @instance_parameters = parameters[:instance]
+          @redis_instance = parameters[:instance]
         end
 
         def result
           value = ""
           status = Status::OK
           begin
-            if instance_parameters.nil?
+            if redis_instance.nil?
               status = Status::ERROR
               value = "Redis instance parameters not found"
             elsif defined?(::Redis)
-              value = instance_parameters.connected?
+              value = redis_instance.connected?
               status = value ? Status::OK : Status::ERROR
             else
               status = Status::ERROR

--- a/lib/rack/ecg/check/redis_connection.rb
+++ b/lib/rack/ecg/check/redis_connection.rb
@@ -3,17 +3,26 @@ module Rack
   class ECG
     module Check
       # @!method initialize
-      #   Checks whether the global Redis client is currently connected to the
-      #   database.
+      #   Checks whether the given Redis client is currently connected to the
+      #   database as identified by the ++instance++ option.
       #
-      #   Does not take any options.
+      # @option parameters instance [Redis,Hash] Redis parameters to check
       class RedisConnection
+        attr_reader :instance_parameters
+
+        def initialize(parameters = {})
+          @instance_parameters = parameters[:instance]
+        end
+
         def result
           value = ""
           status = Status::OK
           begin
-            if defined?(::Redis)
-              value = ::Redis.current.connected?
+            if instance_parameters.nil?
+              status = Status::ERROR
+              value = "Redis instance parameters not found"
+            elsif defined?(::Redis)
+              value = instance_parameters.connected?
               status = value ? Status::OK : Status::ERROR
             else
               status = Status::ERROR

--- a/lib/rack/ecg/check/redis_connection.rb
+++ b/lib/rack/ecg/check/redis_connection.rb
@@ -6,7 +6,7 @@ module Rack
       #   Checks whether the given Redis client is currently connected to the
       #   database as identified by the ++instance++ option.
       #
-      # @option parameters instance [Redis,Hash] Redis parameters to check
+      # @option parameters instance [Redis] The Redis client
       class RedisConnection
         attr_reader :redis_instance
 


### PR DESCRIPTION
Redis-rb, the Redis gem used by Rails apps, is deprecating a part of its
API which stores a global Redis connection. See
https://github.com/redis/redis-rb/issues/1064 for context around that
deprecation.

To prepare for when this behavior will be removed, we must update this
application so that Redis will be passed in as an instance to be
checked, because it will not be globally available.

See https://github.com/envato/marketplace/pull/29383 for more information