### PR TITLE
Deprecate git_revision check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Changed
-
-- **Breaking**: The Redis check now requires being configured with an instance of the Redis client, via the named `instance` parameter
-
 ### Added
 
 - The `static` check, which uses the provided check parameters to return the same result every time.
 
+### Changed
+
+- **Breaking**: The Redis check now requires being configured with an instance of the Redis client, via the named `instance` parameter
+- **Deprecated**: The `git_revision` check will be removed in rack-ecg version 1.0.0. For a suggested replacement, [see the GitRevision Check Replacement example](./examples/gitrevision_check_replacement.ru), which uses the `static` check to memoize the value.
 
 ## [0.1.0] - 2020-12-16
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Does not support configuration. Always returns the following:
 
 #### `git_revision`
 
+**Deprecated**: will be removed in version 1.0.0. [See the GitRevision Check Replacement example](./examples/git_revision_check_replacement.ru), which uses the `static` check to memoize the value.
+
 Requires the `git` executable on path, and that the application's working directory is within a Git repository. Does not support configuration. On success, returns something in the following format:
 
 ```json

--- a/examples/git_revision_check_replacement.ru
+++ b/examples/git_revision_check_replacement.ru
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "rack/ecg"
+
+# This example behaves just like the deprecated GitRevision check, except that the value is memoized.
+#   i.e. "Fetching the git revision" shouldn't show up for every `GET /_ecg` request.
+#
+# Also consider writing the git revision to a file, or storing it in an environment variable, so it can found more
+# efficiently and with fewer dependencies.
+
+def git_revision
+  puts "Fetching the git revision"
+
+  _stdin, stdout, stderr, wait_thread = Open3.popen3("git rev-parse HEAD")
+
+  success = wait_thread.value.success?
+
+  status = success ? Rack::ECG::Check::Status::OK : Rack::ECG::Check::Status::ERROR
+
+  value = success ? stdout.read : stderr.read
+  value = value.strip
+
+  { name: :git_revision, status: status, value: value }
+end
+
+use(Rack::ECG, { checks: [[:static, git_revision]] })
+
+run(-> (_env) { [200, {}, ["Hello, World"]] })

--- a/lib/rack/ecg/check/git_revision.rb
+++ b/lib/rack/ecg/check/git_revision.rb
@@ -2,6 +2,10 @@
 module Rack
   class ECG
     module Check
+      # @deprecated This check requires the presence of the git executable, and executes it every time to determine the
+      #   current revision. Consider checking the revision at initialization time, and returning it via a {Static} check
+      #   instead.
+      #
       # @!method initialize
       #   Returns the SHA1 of the current commit, as reported by the git
       #   executable.


### PR DESCRIPTION
### Context

Follow-up on #35 

The git_revision check requires that the git executable is present, and that the current working directory is a relevant git repository. Additionally, it runs the git executable to determine the current revision on every call to Rack::ECG.

Given industry practices around immutable instances, it is unlikely that the git revision for an application will change at runtime. Therefore, calling git repeatedly introduces overhead. Additionally, when building Docker/OCI images, industry practices recommend minimizing extra dependencies or files - therefore, it is unlikely that either the git executable, or the git repository data, will be available in the running image.

Now that the static check exists, there is a migration path to allow consumers to either:

* migrate to a memoized version of the existing check, or
* expose a result for git_revision via some other means, e.g. recording the git revision in an application image at build time, and loading that from a file or environment variable.

### Changes

- Mark the `git_revision` check as deprecated
- Add an example which demonstrates a potential migration pathway for current users of the `git_revision` check