### PR TITLE
Investigating build failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test (Ruby ${{ matrix.ruby }})
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/lib/rack/ecg/check_registry.rb
+++ b/lib/rack/ecg/check_registry.rb
@@ -40,7 +40,7 @@ module Rack
         def register(name, check_class)
           instance.register(name, check_class)
         end
-    end
+      end
     end
   end
 end

--- a/rack-ecg.gemspec
+++ b/rack-ecg.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("rack")
 
   spec.add_development_dependency("pry", "~> 0.14.1")
-  spec.add_development_dependency("rack-test", "~> 2.0.2")
+  spec.add_development_dependency("rack-test", "~> 2.1.0")
   spec.add_development_dependency("rake", "~> 13.0")
   spec.add_development_dependency("redcarpet", "~> 3.5.0")
   spec.add_development_dependency("rspec", "~> 3.11.0")

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe("when used as middleware") do
               class << self
                 def connection
                 end
-            end
+              end
             end
           end
           expect(ActiveRecord::Base).to(receive(:connection).and_return(connection))
@@ -178,7 +178,7 @@ RSpec.describe("when used as middleware") do
               class << self
                 def connection
                 end
-            end
+              end
             end
           end
           expect(ActiveRecord::Base).to(receive(:connection).and_return(connection))
@@ -268,7 +268,7 @@ RSpec.describe("when used as middleware") do
             class << self
               def connect(_)
               end
-          end
+            end
           end
           expect(Sequel).to(receive(:connect).with("sqlite://").and_yield(instance))
           expect(instance).to(receive(:test_connection).and_return(true))


### PR DESCRIPTION
Branched from https://github.com/envato/rack-ecg/pull/50 which has failing builds

Problems Resolved:

1) .github/workflows/test.yml references actions/checkout@v2 which uses the now deprecated node 12. v3 defaults to node 16.

Some links about that:
https://github.com/actions/checkout/issues/1047
https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300

2) Rubocop offenses. Specifically several instances of the below.

```
lib/rack/ecg/check_registry.rb:43:5: W: [Correctable] Layout/EndAlignment: end at 43, 4 is not aligned with class at 33, 6.
    end
    ^^^
```