### PR TITLE
Adding ruby 3.2 to the tested versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     name: Test (Ruby ${{ matrix.ruby }})
     steps:

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ migrations stored in `schema_versions` table
 ## Maintainers
 
 - [Liam Dawson](https://github.com/liamdawson)
+- [Andrew Davis](https://github.com/andyjdavis)
 
 ## Contributors
 


### PR DESCRIPTION
Ruby 3.2 has been out a while now so it seems worthwhile to include it in the set of versions being tested. Let me know if this isn't a good idea :)