### PR TITLE
Add failure_status option and spec.

### DIFF
--- a/lib/rack/ecg.rb
+++ b/lib/rack/ecg.rb
@@ -11,6 +11,8 @@ module Rack
     DEFAULT_MOUNT_AT = "/_ecg"
     # Checks enabled by default.
     DEFAULT_CHECKS = [:http]
+    # Default failure response status.
+    DEFAULT_FAILURE_STATUS = 500
 
     # Constructs an instance of ECG Rack middleware with the specified
     # options.
@@ -22,7 +24,7 @@ module Rack
     # @param at [String, nil] Path which this ECG instance handles.
     # @param hook [#call, nil] Callable which receives the success status and
     #   check results
-    def initialize(app = nil, checks: DEFAULT_CHECKS, at: DEFAULT_MOUNT_AT, hook: nil)
+    def initialize(app = nil, checks: DEFAULT_CHECKS, at: DEFAULT_MOUNT_AT, hook: nil, failure_status: DEFAULT_FAILURE_STATUS)
       @app = app
 
       check_configuration = checks || []
@@ -30,6 +32,8 @@ module Rack
       @mount_at = at || DEFAULT_MOUNT_AT
 
       @result_hook = hook
+
+      @failure_response_status = failure_status
     end
 
     # Rack compatible call method. Not intended for direct usage.
@@ -41,7 +45,7 @@ module Rack
 
         success = check_results.none? { |check| check[1][:status] == Check::Status::ERROR }
 
-        response_status = success ? 200 : 500
+        response_status = success ? 200 : @failure_response_status
 
         @result_hook&.call(success, check_results)
 

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -67,9 +67,19 @@ RSpec.describe("when used as middleware") do
       let(:options) do
         { checks: [:error] }
       end
-      it "has a success error code" do
+      it "has a failure error code" do
         get "_ecg"
         expect(last_response.status).to(eq(500))
+      end
+
+      context "with failure status option" do
+        let(:options) do
+          { checks: [:error], failure_status: 503 }
+        end
+        it "has a failure error code" do
+          get "_ecg"
+          expect(last_response.status).to(eq(503))
+        end
       end
     end
 


### PR DESCRIPTION
Dear Rack::ECG maintainers

First of all, thanks so much for a useful gem! 🙇🏻‍♂️

I wanted to return a more specific HTTP code when a check failed, in my case a 503 Service Unavailable. I added the necessary option `failure_status`, code, and a spec.

Please let me know if the PR needs improvements and I'll update it.