### PR TITLE
Fix Rack::Response#header deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolved Rack::Response#header deprecation warnings when running rspec
+
 ## [0.3.0] - 2023-09-08
 
 ### Added

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe("when used as middleware") do
 
     it "doesn't include an X-Rack-ECG-Version custom header" do
       get "/hello/world"
-      expect(last_response.header["X-Rack-ECG-Version"]).to(be_nil)
+      expect(last_response.headers["X-Rack-ECG-Version"]).to(be_nil)
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe("when used as middleware") do
 
     it "includes an X-Rack-ECG-Version custom header" do
       get "/_ecg"
-      expect(last_response.header["X-Rack-ECG-Version"]).to(eq(Rack::ECG::VERSION))
+      expect(last_response.headers["X-Rack-ECG-Version"]).to(eq(Rack::ECG::VERSION))
     end
 
     context "when `at` config option is set" do
@@ -52,7 +52,7 @@ RSpec.describe("when used as middleware") do
 
       it "responds from that path" do
         get "/health_check"
-        expect(last_response.header["X-Rack-ECG-Version"]).to(eq(Rack::ECG::VERSION))
+        expect(last_response.headers["X-Rack-ECG-Version"]).to(eq(Rack::ECG::VERSION))
       end
     end
 


### PR DESCRIPTION
There were several instances of this deprecation warning when running rspec `spec/rack_middleware_spec.rb:33: warning: Rack::Response#header is deprecated and will be removed in Rack 3.1`