### PR TITLE
Loose version constraints on development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,14 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in rack-ecg.gemspec
 gemspec
+
+group :development, :test do
+  gem "pry", "~> 0.14.2"
+  gem "rack-test", "~> 2.1.0"
+  gem "rackup", "~> 2.1.0"
+  gem "rake", "~> 13.0"
+  gem "redcarpet", "~> 3.6.0"
+  gem "rspec", "~> 3.12.0"
+  gem "rubocop-shopify", "~> 2.14"
+  gem "yard", "~> 0.9.34"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,11 @@ gemspec
 
 group :development, :test do
   gem "pry", "~> 0.14.2"
-  gem "rack-test", "~> 2.1.0"
-  gem "rackup", "~> 2.1.0"
+  gem "rack-test", "~> 2.1"
+  gem "rackup", "~> 2.1"
   gem "rake", "~> 13.0"
-  gem "redcarpet", "~> 3.6.0"
-  gem "rspec", "~> 3.12.0"
+  gem "redcarpet", "~> 3.6"
+  gem "rspec", "~> 3.12"
   gem "rubocop-shopify", "~> 2.14"
   gem "yard", "~> 0.9.34"
 end

--- a/rack-ecg.gemspec
+++ b/rack-ecg.gemspec
@@ -33,13 +33,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.add_runtime_dependency("rack")
-
-  spec.add_development_dependency("pry", "~> 0.14.2")
-  spec.add_development_dependency("rack-test", "~> 2.1.0")
-  spec.add_development_dependency("rackup", "~> 2.1.0")
-  spec.add_development_dependency("rake", "~> 13.0")
-  spec.add_development_dependency("redcarpet", "~> 3.6.0")
-  spec.add_development_dependency("rspec", "~> 3.12.0")
-  spec.add_development_dependency("rubocop-shopify", "~> 2.14")
-  spec.add_development_dependency("yard", "~> 0.9.34")
 end


### PR DESCRIPTION
Allow minor version bumps on the following gems:

- rack-test
- rackup
- redcarpet
- rspec